### PR TITLE
Add TOC approval rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Naysayer analyzes GitLab merge requests and automatically:
 Naysayer includes built-in rules for:
 - **🏢 Cost Control** - Warehouse configuration validation
 - **🔒 Security** - Service account compliance  
+- **⚖️ TOC Approval** - TOC oversight for production deployments
 - **📄 Documentation** - Metadata and docs validation
 
 > **📚 Complete Rule Details**: See [Rules Documentation](docs/rules/README.md) for what gets validated, troubleshooting, and examples.
@@ -129,10 +130,12 @@ WAREHOUSE_RULE_ENABLED=true
 | Service Account (Astro) | 🟡 **Medium** | ✅ Conditional | Automated accounts with naming compliance |
 | Warehouse Increase | 🟡 **Medium** | ❌ Never | Requires budget approval |
 | Service Account (Other) | 🔴 **High** | ❌ Never | Security review required |
+| **New Product (Prod)** | 🔴 **High** | ❌ Never | Requires TOC governance approval |
 
 ### 🚫 **Manual Review Triggers**
 
 - **Cost Increases** - Warehouse size increases require budget approval
+- **New Production Deployments** - New product.yaml files in preprod/prod require TOC approval
 - **Security Violations** - Hardcoded secrets, invalid domains
 - **Configuration Errors** - YAML syntax errors, missing fields
 - **Uncovered Changes** - Lines not validated by any rule

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -24,6 +24,12 @@ This directory contains detailed documentation for each validation rule implemen
 **Purpose**: Development velocity and documentation quality  
 **Key behavior**: Auto-approves all documentation and metadata changes (zero risk)
 
+### ⚖️ [TOC Approval Rule](TOC_APPROVAL_RULE.md)
+**Validates**: New data product deployments to production environments  
+**Triggers on**: New `**/product.{yaml,yml}` files in preprod/prod paths  
+**Purpose**: Governance oversight and production deployment control  
+**Key behavior**: Requires TOC approval for new products in critical environments
+
 ## 🎯 Quick Problem Resolution
 
 ### My MR is Blocked - What Now?
@@ -38,6 +44,7 @@ This directory contains detailed documentation for each validation rule implemen
 | **File Pattern** | **Rule** | **Common Issues** | **Quick Fix** |
 |------------------|----------|-------------------|---------------|
 | `**/product.{yaml,yml}` | [Warehouse](WAREHOUSE_RULE.md) | Size increases, YAML syntax | Use `XSMALL`/`SMALL`/`MEDIUM`/`LARGE`, validate YAML |
+| `**/product.{yaml,yml}` (new) | [TOC Approval](TOC_APPROVAL_RULE.md) | New products in prod/preprod | Get TOC approval or deploy to dev/test first |
 | `**/*serviceaccount*.{yaml,yml}` | [Service Account](SERVICE_ACCOUNT_RULE.md) | Non-Astro accounts, domain violations | Use Astro patterns, @redhat.com emails |
 | `**/*.md`, docs files | [Metadata](METADATA_RULE.md) | File access issues | Check file permissions, valid UTF-8 encoding |
 

--- a/docs/rules/TOC_APPROVAL_RULE.md
+++ b/docs/rules/TOC_APPROVAL_RULE.md
@@ -1,0 +1,190 @@
+# TOC Approval Rule (`toc_approval` package)
+
+The TOC (Technical Oversight Committee) Approval Rule ensures that new data products being promoted to production or pre-production environments receive proper governance oversight before deployment.
+
+**Package**: `internal/rules/toc_approval`
+
+## ⚖️ Rule Purpose
+
+**Objective**: Require manual review and TOC approval for new `product.yaml` files being deployed to critical environments
+
+**Risk Level**: 🔴 **High** - New products in production environments require governance oversight
+
+## 🔧 How It Works
+
+### Detection Logic
+The rule identifies when:
+1. **New File**: A `product.yaml` file is being added (not modified)
+2. **Critical Environment**: The file path contains preprod or prod environment indicators
+3. **Data Product**: The file is a data product configuration
+
+### Environment Detection
+The rule checks file paths for environment indicators:
+- `/preprod/` - Pre-production environment
+- `/prod/` - Production environment  
+- `_preprod_` - Pre-production naming convention
+- `_prod_` - Production naming convention
+
+### Examples of Triggering Paths
+```
+✅ REQUIRES TOC APPROVAL:
+dataproducts/analytics/prod/product.yaml        # New file in prod
+dataproducts/source/preprod/product.yaml        # New file in preprod
+dataproducts/ml/my_prod_setup/product.yaml      # New file with prod in path
+
+❌ NO TOC APPROVAL NEEDED:
+dataproducts/analytics/prod/product.yaml        # Existing file modification
+dataproducts/analytics/dev/product.yaml         # New file in dev environment
+dataproducts/analytics/test/product.yaml        # New file in test environment
+```
+
+## 🎯 Decision Logic
+
+| **Condition** | **Decision** | **Reason** |
+|---------------|--------------|------------|
+| New `product.yaml` in prod/preprod | 🔍 **Manual Review** | TOC approval required for production deployments |
+| Existing `product.yaml` in prod/preprod | ✅ **Auto-approve** | Modifications to existing products don't need TOC |
+| New `product.yaml` in dev/test | ✅ **Auto-approve** | Development environments don't require TOC |
+| Non-product files | ✅ **Auto-approve** | Rule only applies to product configurations |
+
+## 🚫 Manual Review Triggers
+
+### When TOC Approval is Required
+- **New Data Product Promotion**: First-time deployment to production environments
+- **Business Impact**: New products may have significant business or operational impact
+- **Compliance**: Production deployments must follow governance processes
+
+### Review Process
+1. **Automatic Detection**: Naysayer flags the MR for manual review
+2. **TOC Notification**: Technical Oversight Committee is notified
+3. **Review Criteria**: TOC evaluates:
+   - Business justification
+   - Technical readiness
+   - Security compliance
+   - Resource requirements
+4. **Manual Approval**: TOC member manually approves the MR
+
+## ⚙️ Configuration
+
+### Environment Variables
+```bash
+# Configure which environments require TOC approval
+WAREHOUSE_PLATFORM_ENVS=preprod,prod
+SA_ASTRO_ENVS=preprod,prod
+```
+
+### Rules Configuration (rules.yaml)
+```yaml
+files:
+  - name: "product_configs"
+    path: "**/dataproducts/**/"
+    filename: "product.{yaml,yml}"
+    sections:
+      - name: full_file_toc_validation
+        yaml_path: .
+        rule_configs:
+          - name: toc_approval_rule
+            enabled: true
+        auto_approve: false
+```
+
+## 🔍 Example Scenarios
+
+### Scenario 1: New Production Deployment
+```yaml
+# File: dataproducts/analytics/prod/product.yaml (NEW FILE)
+name: customer-analytics
+version: 1.0.0
+warehouses:
+  - type: user
+    size: LARGE
+```
+**Result**: 🔍 Manual review required - TOC approval needed
+
+### Scenario 2: Development Environment
+```yaml
+# File: dataproducts/analytics/dev/product.yaml (NEW FILE)
+name: customer-analytics
+version: 1.0.0
+```
+**Result**: ✅ Auto-approved - Development environment
+
+### Scenario 3: Existing Product Update
+```yaml
+# File: dataproducts/analytics/prod/product.yaml (EXISTING FILE)
+name: customer-analytics
+version: 1.1.0  # Version bump
+```
+**Result**: ✅ Auto-approved - Existing product modification
+
+## 📋 Compliance & Audit
+
+### Audit Trail
+All TOC approval decisions are logged with:
+- Timestamp of review request
+- Environment being deployed to
+- Product name and configuration
+- TOC member who approved
+- Business justification
+
+### Governance Integration
+- **JIRA Integration**: Automatic ticket creation for TOC review
+- **Slack Notifications**: Real-time alerts to TOC channel
+- **Dashboard Tracking**: Metrics on approval times and patterns
+
+## 🛠️ Troubleshooting
+
+### Common Issues
+
+**Issue**: False positives for development environments
+```
+Solution: Ensure dev environment paths don't contain "prod" keywords
+✅ Good: dataproducts/analytics/development/
+❌ Avoid: dataproducts/analytics/dev-production/
+```
+
+**Issue**: TOC approval for non-critical changes
+```
+Solution: Use separate branches/paths for non-production testing
+✅ Good: dataproducts/analytics/staging/
+❌ Avoid: dataproducts/analytics/prod/ for testing
+```
+
+### Debug Commands
+```bash
+# Check which environments trigger TOC approval
+grep -r "preprod\|prod" dataproducts/
+
+# Verify file is detected as new
+git status --porcelain | grep "^A"
+```
+
+## 🎯 Best Practices
+
+### Development Workflow
+1. **Test First**: Deploy to dev/test environments first
+2. **Document Changes**: Include business justification in MR description  
+3. **Early TOC Engagement**: Notify TOC before creating production MRs
+4. **Staged Rollouts**: Use preprod for final validation before prod
+
+### Path Naming Conventions
+```bash
+✅ RECOMMENDED:
+dataproducts/[team]/[env]/product.yaml
+dataproducts/analytics/prod/product.yaml
+dataproducts/ml/preprod/product.yaml
+
+❌ AVOID:
+dataproducts/analytics/production-test/product.yaml  # Contains "prod"
+dataproducts/ml/prod-backup/product.yaml            # Contains "prod"
+```
+
+## 🔗 Related Rules
+
+- **Warehouse Rule**: Validates cost implications of new production deployments
+- **Service Account Rule**: Ensures proper security for production environments
+- **Metadata Rule**: Validates documentation completeness for production systems
+
+---
+
+**⚠️ Important**: This rule helps maintain production stability and governance compliance. Contact the TOC team for expedited reviews when needed.

--- a/internal/rules/toc_approval/rule.go
+++ b/internal/rules/toc_approval/rule.go
@@ -1,0 +1,154 @@
+package toc_approval
+
+import (
+	"strings"
+
+	"github.com/redhat-data-and-ai/naysayer/internal/rules/common"
+	"github.com/redhat-data-and-ai/naysayer/internal/rules/shared"
+)
+
+// TOCApprovalRule requires TOC approval for new product.yaml files in preprod/prod environments
+type TOCApprovalRule struct {
+	*common.BaseRule
+	*common.FileTypeMatcher
+	*common.ValidationHelper
+	config *TOCEnvironmentConfig
+}
+
+// NewTOCApprovalRule creates a new TOC approval rule instance
+func NewTOCApprovalRule(preprodProdEnvs []string) *TOCApprovalRule {
+	config := DefaultTOCEnvironmentConfig()
+	if preprodProdEnvs != nil {
+		config.RequiredEnvironments = preprodProdEnvs
+	}
+
+	return &TOCApprovalRule{
+		BaseRule:         common.NewBaseRule("toc_approval_rule", "Requires TOC approval for new product.yaml files in preprod/prod environments"),
+		FileTypeMatcher:  common.NewFileTypeMatcher(),
+		ValidationHelper: common.NewValidationHelper(),
+		config:           config,
+	}
+}
+
+// ValidateLines validates lines for TOC approval requirements
+func (r *TOCApprovalRule) ValidateLines(filePath string, fileContent string, lineRanges []shared.LineRange) (shared.DecisionType, string) {
+	// Only apply to product.yaml files
+	if !r.IsProductFile(filePath) {
+		return r.CreateApprovalResult("Not a product.yaml file - no TOC approval required")
+	}
+
+	// Analyze the context for this file
+	context := r.analyzeFile(filePath)
+
+	if context.RequiresApproval {
+		return r.CreateManualReviewResult(context.ApprovalReason)
+	}
+
+	// For existing files or non-critical environments, no TOC approval needed
+	return r.CreateApprovalResult("Existing product.yaml file or not in critical environment - no TOC approval required")
+}
+
+// GetCoveredLines returns line ranges this rule covers
+func (r *TOCApprovalRule) GetCoveredLines(filePath string, fileContent string) []shared.LineRange {
+	// Only cover product.yaml files
+	if !r.IsProductFile(filePath) {
+		return []shared.LineRange{}
+	}
+
+	context := r.analyzeFile(filePath)
+
+	// Cover the entire file for new products in critical environments
+	if context.RequiresApproval {
+		return r.GetFullFileCoverage(filePath, fileContent)
+	}
+
+	// Return minimal coverage for existing files to participate in validation
+	return []shared.LineRange{
+		{
+			StartLine: 1,
+			EndLine:   1,
+			FilePath:  filePath,
+		},
+	}
+}
+
+// analyzeFile analyzes a file to determine if TOC approval is required
+func (r *TOCApprovalRule) analyzeFile(filePath string) *TOCApprovalContext {
+	context := &TOCApprovalContext{
+		FilePath:         filePath,
+		IsNewFile:        r.isNewFile(filePath),
+		Environment:      r.extractEnvironmentFromPath(filePath),
+		RequiresApproval: false,
+	}
+
+	// Check if this is a new file in a critical environment
+	if context.IsNewFile && r.isEnvironmentCritical(context.Environment) {
+		context.RequiresApproval = true
+		context.ApprovalReason = r.getTOCApprovalReason(filePath, context.Environment)
+	}
+
+	return context
+}
+
+// isNewFile checks if this file is being added (new file)
+func (r *TOCApprovalRule) isNewFile(filePath string) bool {
+	if r.GetMRContext() == nil {
+		return false
+	}
+
+	// Check if this file is being added (new file)
+	for _, change := range r.GetMRContext().Changes {
+		if change.NewPath == filePath && change.NewFile {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isEnvironmentCritical checks if the environment requires TOC approval
+func (r *TOCApprovalRule) isEnvironmentCritical(environment string) bool {
+	if environment == "" {
+		return false
+	}
+
+	for _, criticalEnv := range r.config.RequiredEnvironments {
+		if r.config.CaseSensitive {
+			if environment == criticalEnv {
+				return true
+			}
+		} else {
+			if strings.EqualFold(environment, criticalEnv) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+// extractEnvironmentFromPath attempts to extract the environment name from the file path
+func (r *TOCApprovalRule) extractEnvironmentFromPath(filePath string) string {
+	lowerPath := strings.ToLower(filePath)
+
+	for _, env := range r.config.RequiredEnvironments {
+		lowerEnv := strings.ToLower(env)
+		if strings.Contains(lowerPath, "/"+lowerEnv+"/") ||
+			strings.Contains(lowerPath, "/"+lowerEnv+"_") ||
+			strings.Contains(lowerPath, "_"+lowerEnv+"/") ||
+			strings.Contains(lowerPath, "_"+lowerEnv+"_") {
+			return env
+		}
+	}
+
+	return ""
+}
+
+// getTOCApprovalReason returns a detailed reason for requiring TOC approval
+func (r *TOCApprovalRule) getTOCApprovalReason(filePath, environment string) string {
+	if environment != "" {
+		return "Manual review required: New data product being promoted to " + environment + " environment requires TOC (Technical Oversight Committee) approval before deployment"
+	}
+
+	return "Manual review required: New data product in critical environment requires TOC (Technical Oversight Committee) approval before deployment"
+}

--- a/internal/rules/toc_approval/rule_test.go
+++ b/internal/rules/toc_approval/rule_test.go
@@ -1,0 +1,363 @@
+package toc_approval
+
+import (
+	"testing"
+
+	"github.com/redhat-data-and-ai/naysayer/internal/gitlab"
+	"github.com/redhat-data-and-ai/naysayer/internal/rules/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTOCApprovalRule(t *testing.T) {
+	tests := []struct {
+		name            string
+		preprodProdEnvs []string
+		expectedName    string
+		expectedEnvs    []string
+	}{
+		{
+			name:            "with custom environments",
+			preprodProdEnvs: []string{"staging", "production"},
+			expectedName:    "toc_approval_rule",
+			expectedEnvs:    []string{"staging", "production"},
+		},
+		{
+			name:            "with nil environments (should use defaults)",
+			preprodProdEnvs: nil,
+			expectedName:    "toc_approval_rule",
+			expectedEnvs:    []string{"preprod", "prod"},
+		},
+		{
+			name:            "with empty environments",
+			preprodProdEnvs: []string{},
+			expectedName:    "toc_approval_rule",
+			expectedEnvs:    []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewTOCApprovalRule(tt.preprodProdEnvs)
+
+			assert.Equal(t, tt.expectedName, rule.Name())
+			assert.Contains(t, rule.Description(), "TOC approval")
+			assert.Equal(t, tt.expectedEnvs, rule.config.RequiredEnvironments)
+		})
+	}
+}
+
+func TestTOCApprovalRule_ValidateLines(t *testing.T) {
+	tests := []struct {
+		name                   string
+		filePath               string
+		fileContent            string
+		mrContext              *shared.MRContext
+		expectedDecision       shared.DecisionType
+		expectedReasonContains string
+	}{
+		{
+			name:                   "non-product file should approve",
+			filePath:               "dataproducts/test/README.md",
+			fileContent:            "# Test",
+			mrContext:              &shared.MRContext{},
+			expectedDecision:       shared.Approve,
+			expectedReasonContains: "Not a product.yaml file",
+		},
+		{
+			name:        "new product.yaml in prod environment should require manual review",
+			filePath:    "dataproducts/analytics/prod/product.yaml",
+			fileContent: "name: test-product\nversion: 1.0",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/analytics/prod/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedDecision:       shared.ManualReview,
+			expectedReasonContains: "TOC (Technical Oversight Committee) approval",
+		},
+		{
+			name:        "new product.yaml in preprod environment should require manual review",
+			filePath:    "dataproducts/analytics/preprod/product.yaml",
+			fileContent: "name: test-product\nversion: 1.0",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/analytics/preprod/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedDecision:       shared.ManualReview,
+			expectedReasonContains: "preprod environment requires TOC",
+		},
+		{
+			name:        "existing product.yaml in prod should approve",
+			filePath:    "dataproducts/analytics/prod/product.yaml",
+			fileContent: "name: test-product\nversion: 1.0",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						OldPath: "dataproducts/analytics/prod/product.yaml",
+						NewPath: "dataproducts/analytics/prod/product.yaml",
+						NewFile: false,
+					},
+				},
+			},
+			expectedDecision:       shared.Approve,
+			expectedReasonContains: "Existing product.yaml file",
+		},
+		{
+			name:        "new product.yaml in dev environment should approve",
+			filePath:    "dataproducts/analytics/dev/product.yaml",
+			fileContent: "name: test-product\nversion: 1.0",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/analytics/dev/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedDecision:       shared.Approve,
+			expectedReasonContains: "not in critical environment",
+		},
+		{
+			name:        "new product.yaml with prod in filename should require manual review",
+			filePath:    "dataproducts/analytics/my_prod_setup/product.yaml",
+			fileContent: "name: test-product\nversion: 1.0",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/analytics/my_prod_setup/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedDecision:       shared.ManualReview,
+			expectedReasonContains: "TOC (Technical Oversight Committee) approval",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewTOCApprovalRule([]string{"preprod", "prod"})
+			rule.SetMRContext(tt.mrContext)
+
+			lineRanges := []shared.LineRange{
+				{StartLine: 1, EndLine: 2, FilePath: tt.filePath},
+			}
+
+			decision, reason := rule.ValidateLines(tt.filePath, tt.fileContent, lineRanges)
+
+			assert.Equal(t, tt.expectedDecision, decision)
+			assert.Contains(t, reason, tt.expectedReasonContains)
+		})
+	}
+}
+
+func TestTOCApprovalRule_GetCoveredLines(t *testing.T) {
+	tests := []struct {
+		name                string
+		filePath            string
+		fileContent         string
+		mrContext           *shared.MRContext
+		expectedCoverageLen int
+		shouldCoverFullFile bool
+	}{
+		{
+			name:                "non-product file should have no coverage",
+			filePath:            "dataproducts/test/README.md",
+			fileContent:         "# Test",
+			mrContext:           &shared.MRContext{},
+			expectedCoverageLen: 0,
+			shouldCoverFullFile: false,
+		},
+		{
+			name:        "new product.yaml in prod should cover full file",
+			filePath:    "dataproducts/analytics/prod/product.yaml",
+			fileContent: "name: test-product\nversion: 1.0\ntags:\n  - production",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/analytics/prod/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedCoverageLen: 1,
+			shouldCoverFullFile: true,
+		},
+		{
+			name:        "existing product.yaml should have minimal coverage",
+			filePath:    "dataproducts/analytics/prod/product.yaml",
+			fileContent: "name: test-product\nversion: 1.0",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						OldPath: "dataproducts/analytics/prod/product.yaml",
+						NewPath: "dataproducts/analytics/prod/product.yaml",
+						NewFile: false,
+					},
+				},
+			},
+			expectedCoverageLen: 1,
+			shouldCoverFullFile: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewTOCApprovalRule([]string{"preprod", "prod"})
+			rule.SetMRContext(tt.mrContext)
+
+			coveredLines := rule.GetCoveredLines(tt.filePath, tt.fileContent)
+
+			assert.Len(t, coveredLines, tt.expectedCoverageLen)
+
+			if tt.shouldCoverFullFile && len(coveredLines) > 0 {
+				expectedLines := shared.CountLines(tt.fileContent)
+				assert.Equal(t, 1, coveredLines[0].StartLine)
+				assert.Equal(t, expectedLines, coveredLines[0].EndLine)
+			}
+		})
+	}
+}
+
+func TestTOCApprovalRule_analyzeFile(t *testing.T) {
+	tests := []struct {
+		name                     string
+		filePath                 string
+		mrContext                *shared.MRContext
+		expectedRequiresApproval bool
+		expectedEnvironment      string
+	}{
+		{
+			name:     "new file in prod directory",
+			filePath: "dataproducts/analytics/prod/product.yaml",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/analytics/prod/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedRequiresApproval: true,
+			expectedEnvironment:      "prod",
+		},
+		{
+			name:     "new file in preprod directory",
+			filePath: "dataproducts/source/preprod/product.yaml",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/source/preprod/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedRequiresApproval: true,
+			expectedEnvironment:      "preprod",
+		},
+		{
+			name:     "existing file in prod directory",
+			filePath: "dataproducts/analytics/prod/product.yaml",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						OldPath: "dataproducts/analytics/prod/product.yaml",
+						NewPath: "dataproducts/analytics/prod/product.yaml",
+						NewFile: false,
+					},
+				},
+			},
+			expectedRequiresApproval: false,
+			expectedEnvironment:      "prod",
+		},
+		{
+			name:     "new file in dev directory",
+			filePath: "dataproducts/analytics/dev/product.yaml",
+			mrContext: &shared.MRContext{
+				Changes: []gitlab.FileChange{
+					{
+						NewPath: "dataproducts/analytics/dev/product.yaml",
+						NewFile: true,
+					},
+				},
+			},
+			expectedRequiresApproval: false,
+			expectedEnvironment:      "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewTOCApprovalRule([]string{"preprod", "prod"})
+			rule.SetMRContext(tt.mrContext)
+
+			context := rule.analyzeFile(tt.filePath)
+
+			assert.Equal(t, tt.expectedRequiresApproval, context.RequiresApproval)
+			assert.Equal(t, tt.expectedEnvironment, context.Environment)
+			assert.Equal(t, tt.filePath, context.FilePath)
+		})
+	}
+}
+
+func TestTOCApprovalRule_extractEnvironmentFromPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		envs     []string
+		expected string
+	}{
+		{
+			name:     "prod in directory path",
+			filePath: "dataproducts/analytics/prod/product.yaml",
+			envs:     []string{"preprod", "prod"},
+			expected: "prod",
+		},
+		{
+			name:     "preprod in directory path",
+			filePath: "dataproducts/source/preprod/product.yaml",
+			envs:     []string{"preprod", "prod"},
+			expected: "preprod",
+		},
+		{
+			name:     "custom environment staging",
+			filePath: "dataproducts/analytics/staging/product.yaml",
+			envs:     []string{"staging", "production"},
+			expected: "staging",
+		},
+		{
+			name:     "environment with underscore",
+			filePath: "dataproducts/analytics/my_prod_setup/product.yaml",
+			envs:     []string{"preprod", "prod"},
+			expected: "prod",
+		},
+		{
+			name:     "no environment match",
+			filePath: "dataproducts/analytics/dev/product.yaml",
+			envs:     []string{"preprod", "prod"},
+			expected: "",
+		},
+		{
+			name:     "case insensitive matching",
+			filePath: "dataproducts/analytics/PROD/product.yaml",
+			envs:     []string{"preprod", "prod"},
+			expected: "prod",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rule := NewTOCApprovalRule(tt.envs)
+
+			result := rule.extractEnvironmentFromPath(tt.filePath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/rules/toc_approval/types.go
+++ b/internal/rules/toc_approval/types.go
@@ -1,0 +1,27 @@
+package toc_approval
+
+// TOCEnvironmentConfig holds configuration for TOC approval environments
+type TOCEnvironmentConfig struct {
+	// RequiredEnvironments are environments that require TOC approval for new products
+	RequiredEnvironments []string `json:"required_environments"`
+
+	// CaseSensitive determines if environment matching is case sensitive
+	CaseSensitive bool `json:"case_sensitive"`
+}
+
+// DefaultTOCEnvironmentConfig returns the default configuration
+func DefaultTOCEnvironmentConfig() *TOCEnvironmentConfig {
+	return &TOCEnvironmentConfig{
+		RequiredEnvironments: []string{"preprod", "prod"},
+		CaseSensitive:        false,
+	}
+}
+
+// TOCApprovalContext contains context information for TOC approval decisions
+type TOCApprovalContext struct {
+	FilePath         string `json:"file_path"`
+	Environment      string `json:"environment"`
+	IsNewFile        bool   `json:"is_new_file"`
+	RequiresApproval bool   `json:"requires_approval"`
+	ApprovalReason   string `json:"approval_reason"`
+}

--- a/rules.yaml
+++ b/rules.yaml
@@ -5,8 +5,8 @@ enabled: true
 files:
   # Product configuration files - Critical infrastructure validation
   - name: "product_configs"
-    path: "**/dataproducts/**/"
-    filename: "product.{yaml,yml}"
+    path: "dataproducts/**/"
+    filename: "product.yaml"
     parser_type: yaml
     enabled: true
     sections:
@@ -15,6 +15,14 @@ files:
         yaml_path: warehouses
         rule_configs:
           - name: warehouse_rule
+            enabled: true
+        auto_approve: false
+      
+      # Full file validation for new products in preprod/prod
+      - name: full_file_toc_validation
+        yaml_path: .
+        rule_configs:
+          - name: toc_approval_rule
             enabled: true
         auto_approve: false
       
@@ -31,6 +39,8 @@ files:
         rule_configs:
           - name: metadata_rule
             enabled: true
+          - name: toc_approval_rule
+            enabled: true
         auto_approve: true
 
       - name: rover_group
@@ -46,11 +56,25 @@ files:
           - name: metadata_rule
             enabled: true
         auto_approve: true
+        
+  # Documentation files - Auto-approve
+  - name: "documentation_files"
+    path: "*/"
+    filename: "*.md"
+    parser_type: yaml
+    enabled: true
+    sections:
+      - name: full_file_doc_validation
+        yaml_path: .
+        rule_configs:
+          - name: metadata_rule
+            enabled: true
+        auto_approve: true
 
   # Developer metadata files - Low risk, can auto-approve
   - name: "developer_metadata"
-    path: "**/dataproducts/**/"
-    filename: "developers.{yaml,yml}"
+    path: "dataproducts/**/"
+    filename: "developers.yaml"
     parser_type: yaml
     enabled: true
     sections:
@@ -65,7 +89,6 @@ files:
 # Any file type not explicitly configured above will require manual review by default.
 # This includes:
 #   - .sql files (migration scripts) - CRITICAL: Always require manual review
-#   - .md files (documentation) - Should be reviewed
 #   - .gitlab-ci.yml (CI configuration) - Security-critical
 #   - .yaml/.yml files not matching patterns above - Require review
 #   - Any other file types - Default to manual review


### PR DESCRIPTION
## Description

Add a check for TOC approval requirement. If the dataproduct (product.yaml) is getting promoted to preprod or prod for the first time, we will not auto-approve the TOC approval rule.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [x] 🧪 Test addition or improvement
- [ ] 🔨 Build/CI changes

## Related Issues

Fixes #(issue number)

## Testing

- [x] Unit tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] Manual testing completed
- [x] Coverage maintained or improved
