### PR TITLE
feat: Add codeowners_sync_rule to auto-approve CODEOWNERS sync changes

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.9'
         cache: true
 
     - name: Cache Go modules
@@ -86,7 +86,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.9'
 
     - name: Run Gosec Security Scanner
       run: |
@@ -119,7 +119,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25.8'
+        go-version: '1.25.9'
         cache: true
 
     - name: Cache Go modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
 RUN microdnf install -y tar gzip ca-certificates
 
 # Install Go
-RUN curl -OL https://go.dev/dl/go1.25.8.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.25.8.linux-amd64.tar.gz
+RUN curl -OL https://go.dev/dl/go1.25.9.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.25.9.linux-amd64.tar.gz
 
 WORKDIR /app
 

--- a/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/after/CODEOWNERS
+++ b/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/after/CODEOWNERS
@@ -1,0 +1,3 @@
+# Data Product Owners
+[Aggregate Data Products]
+/dataproducts/aggregate/analytics/ @alice @bob @charlie

--- a/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/after/dataproducts/aggregate/analytics/developers.yaml
+++ b/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/after/dataproducts/aggregate/analytics/developers.yaml
@@ -1,0 +1,5 @@
+group:
+  owners:
+    - alice
+    - bob
+    - charlie

--- a/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/before/CODEOWNERS
+++ b/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/before/CODEOWNERS
@@ -1,0 +1,3 @@
+# Data Product Owners
+[Aggregate Data Products]
+/dataproducts/aggregate/analytics/ @alice @bob

--- a/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/before/dataproducts/aggregate/analytics/developers.yaml
+++ b/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/before/dataproducts/aggregate/analytics/developers.yaml
@@ -1,0 +1,4 @@
+group:
+  owners:
+    - alice
+    - bob

--- a/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/scenario.yaml
+++ b/e2e/testdata/scenarios/38_codeowners_existing_dp_owner_update/scenario.yaml
@@ -1,0 +1,15 @@
+name: "CODEOWNERS sync - existing DP owner update"
+description: "Auto-approve CODEOWNERS when developers.yaml owners are updated for existing data product"
+
+expected:
+  decision: Approve
+  reason: "All files passed validation"
+  approved: true
+  comment_contains:
+    - "✅ **Auto-approved**"
+
+mr_metadata:
+  title: "Add new owner to analytics data product"
+  author: "testuser"
+  source_branch: "feature/add-owner"
+  target_branch: "main"

--- a/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/after/CODEOWNERS
+++ b/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/after/CODEOWNERS
@@ -1,0 +1,5 @@
+# Data Product Owners
+[Aggregate Data Products]
+/dataproducts/aggregate/analytics/ @alice @bob
+/dataproducts/aggregate/analytics/groups/test-consumer-group.yaml @approver1 @approver2
+/dataproducts/aggregate/analytics/access-requests/groups/test-consumer-group/ @approver1 @approver2

--- a/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/after/dataproducts/aggregate/analytics/developers.yaml
+++ b/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/after/dataproducts/aggregate/analytics/developers.yaml
@@ -1,0 +1,4 @@
+group:
+  owners:
+    - alice
+    - bob

--- a/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/after/dataproducts/aggregate/analytics/groups/test-consumer-group.yaml
+++ b/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/after/dataproducts/aggregate/analytics/groups/test-consumer-group.yaml
@@ -1,0 +1,4 @@
+group_name: test-consumer-group
+approvers:
+  - approver1
+  - approver2

--- a/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/before/CODEOWNERS
+++ b/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/before/CODEOWNERS
@@ -1,0 +1,3 @@
+# Data Product Owners
+[Aggregate Data Products]
+/dataproducts/aggregate/analytics/ @alice @bob

--- a/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/before/dataproducts/aggregate/analytics/developers.yaml
+++ b/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/before/dataproducts/aggregate/analytics/developers.yaml
@@ -1,0 +1,4 @@
+group:
+  owners:
+    - alice
+    - bob

--- a/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/scenario.yaml
+++ b/e2e/testdata/scenarios/39_codeowners_new_group_existing_dp/scenario.yaml
@@ -1,0 +1,15 @@
+name: "CODEOWNERS sync - new group in existing DP"
+description: "Auto-approve CODEOWNERS when new group is added to existing data product"
+
+expected:
+  decision: Approve
+  reason: "All files passed validation"
+  approved: true
+  comment_contains:
+    - "✅ **Auto-approved**"
+
+mr_metadata:
+  title: "Add consumer group to analytics data product"
+  author: "testuser"
+  source_branch: "feature/add-consumer-group"
+  target_branch: "main"

--- a/e2e/testdata/scenarios/40_codeowners_new_dataproduct/after/CODEOWNERS
+++ b/e2e/testdata/scenarios/40_codeowners_new_dataproduct/after/CODEOWNERS
@@ -1,0 +1,3 @@
+# Data Product Owners
+[Aggregate Data Products]
+/dataproducts/aggregate/newproduct/ @newowner1 @newowner2

--- a/e2e/testdata/scenarios/40_codeowners_new_dataproduct/after/dataproducts/aggregate/newproduct/developers.yaml
+++ b/e2e/testdata/scenarios/40_codeowners_new_dataproduct/after/dataproducts/aggregate/newproduct/developers.yaml
@@ -1,0 +1,4 @@
+group:
+  owners:
+    - newowner1
+    - newowner2

--- a/e2e/testdata/scenarios/40_codeowners_new_dataproduct/before/CODEOWNERS
+++ b/e2e/testdata/scenarios/40_codeowners_new_dataproduct/before/CODEOWNERS
@@ -1,0 +1,3 @@
+# Data Product Owners
+[Aggregate Data Products]
+# No data products yet

--- a/e2e/testdata/scenarios/40_codeowners_new_dataproduct/scenario.yaml
+++ b/e2e/testdata/scenarios/40_codeowners_new_dataproduct/scenario.yaml
@@ -1,0 +1,15 @@
+name: "CODEOWNERS sync - new data product"
+description: "Manual review required when new data product is created"
+
+expected:
+  decision: ManualReview
+  reason: "manual review"
+  approved: false
+  comment_contains:
+    - "Manual review required"
+
+mr_metadata:
+  title: "Create new data product"
+  author: "testuser"
+  source_branch: "feature/new-dp"
+  target_branch: "main"

--- a/e2e/testdata/scenarios/41_codeowners_no_yaml_changes/after/CODEOWNERS
+++ b/e2e/testdata/scenarios/41_codeowners_no_yaml_changes/after/CODEOWNERS
@@ -1,0 +1,3 @@
+# Data Product Owners
+[Aggregate Data Products]
+/dataproducts/aggregate/analytics/ @alice @bob @unauthorized

--- a/e2e/testdata/scenarios/41_codeowners_no_yaml_changes/before/CODEOWNERS
+++ b/e2e/testdata/scenarios/41_codeowners_no_yaml_changes/before/CODEOWNERS
@@ -1,0 +1,3 @@
+# Data Product Owners
+[Aggregate Data Products]
+/dataproducts/aggregate/analytics/ @alice @bob

--- a/e2e/testdata/scenarios/41_codeowners_no_yaml_changes/scenario.yaml
+++ b/e2e/testdata/scenarios/41_codeowners_no_yaml_changes/scenario.yaml
@@ -1,0 +1,15 @@
+name: "CODEOWNERS changed without YAML changes"
+description: "Manual review required when CODEOWNERS is modified without corresponding YAML file changes"
+
+expected:
+  decision: ManualReview
+  reason: "manual review"
+  approved: false
+  comment_contains:
+    - "Manual review required"
+
+mr_metadata:
+  title: "Update CODEOWNERS directly"
+  author: "testuser"
+  source_branch: "feature/direct-codeowners-edit"
+  target_branch: "main"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-data-and-ai/naysayer
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.12

--- a/internal/rules/codeowners/rule.go
+++ b/internal/rules/codeowners/rule.go
@@ -1,0 +1,354 @@
+package codeowners
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/redhat-data-and-ai/naysayer/internal/gitlab"
+	"github.com/redhat-data-and-ai/naysayer/internal/logging"
+	"github.com/redhat-data-and-ai/naysayer/internal/rules/common"
+	"github.com/redhat-data-and-ai/naysayer/internal/rules/shared"
+	"gopkg.in/yaml.v3"
+)
+
+// CODEOWNERSSyncRule auto-approves CODEOWNERS changes when they match
+// corresponding developers.yaml or groups/*.yaml changes
+type CODEOWNERSSyncRule struct {
+	*common.BaseRule
+	*common.ValidationHelper
+	client gitlab.GitLabClient
+}
+
+// NewCODEOWNERSSyncRule creates a new CODEOWNERS sync rule instance
+func NewCODEOWNERSSyncRule(client gitlab.GitLabClient) *CODEOWNERSSyncRule {
+	return &CODEOWNERSSyncRule{
+		BaseRule:         common.NewBaseRule("codeowners_sync_rule", "Auto-approves CODEOWNERS changes that match developers.yaml or groups/*.yaml changes"),
+		ValidationHelper: common.NewValidationHelper(),
+		client:           client,
+	}
+}
+
+// ValidateLines validates lines for CODEOWNERS sync
+func (r *CODEOWNERSSyncRule) ValidateLines(filePath string, fileContent string, lineRanges []shared.LineRange) (shared.DecisionType, string) {
+	if !r.isCODEOWNERSFile(filePath) {
+		return r.CreateApprovalResult("Not a CODEOWNERS file - rule does not apply")
+	}
+
+	mrCtx := r.GetMRContext()
+	if mrCtx == nil {
+		return r.CreateManualReviewResult("MR context not available")
+	}
+
+	// Get all YAML changes in this MR
+	yamlChanges := r.getYAMLChanges(mrCtx)
+	if len(yamlChanges) == 0 {
+		return r.CreateManualReviewResult("CODEOWNERS changed without corresponding YAML changes")
+	}
+
+	// Check for new data product (requires manual review)
+	for _, change := range yamlChanges {
+		if change.FileType == "developers" && change.IsNewFile {
+			return r.CreateManualReviewResult("New data product detected - manual review required")
+		}
+		if change.FileType == "group" && change.IsNewFile {
+			if !r.dataProductExists(mrCtx, change.DataProduct) {
+				return r.CreateManualReviewResult("New group in new data product - manual review required")
+			}
+		}
+	}
+
+	// Validate CODEOWNERS changes match YAML changes
+	addedEntries := r.parseAddedCODEOWNERSEntries(mrCtx, filePath)
+	expectedEntries := r.buildExpectedEntries(yamlChanges)
+
+	if reason := r.validateEntriesMatch(expectedEntries, addedEntries); reason != "" {
+		return r.CreateManualReviewResult(reason)
+	}
+
+	return r.CreateApprovalResult("Auto-approved: CODEOWNERS changes match YAML changes")
+}
+
+// GetCoveredLines returns line ranges this rule covers
+func (r *CODEOWNERSSyncRule) GetCoveredLines(filePath string, fileContent string) []shared.LineRange {
+	if !r.isCODEOWNERSFile(filePath) {
+		return []shared.LineRange{}
+	}
+	return r.GetFullFileCoverage(filePath, fileContent)
+}
+
+// isCODEOWNERSFile checks if the file is a CODEOWNERS file
+func (r *CODEOWNERSSyncRule) isCODEOWNERSFile(filePath string) bool {
+	return strings.HasSuffix(strings.ToLower(filePath), "codeowners")
+}
+
+// getYAMLChanges extracts information about changed YAML files from the MR
+func (r *CODEOWNERSSyncRule) getYAMLChanges(mrCtx *shared.MRContext) []YAMLChangeInfo {
+	var changes []YAMLChangeInfo
+
+	for _, change := range mrCtx.Changes {
+		if change.NewPath == "" {
+			continue
+		}
+
+		if info := r.parseDevelopersYAML(mrCtx, change); info != nil {
+			changes = append(changes, *info)
+		} else if info := r.parseGroupYAML(mrCtx, change); info != nil {
+			changes = append(changes, *info)
+		}
+	}
+	return changes
+}
+
+// parseDevelopersYAML parses a developers.yaml change
+func (r *CODEOWNERSSyncRule) parseDevelopersYAML(mrCtx *shared.MRContext, change gitlab.FileChange) *YAMLChangeInfo {
+	if !strings.HasSuffix(change.NewPath, "developers.yaml") && !strings.HasSuffix(change.NewPath, "developers.yml") {
+		return nil
+	}
+
+	dp := r.extractDataProductInfo(change.NewPath)
+	if dp == nil {
+		return nil
+	}
+
+	owners := r.fetchOwners(mrCtx, change.NewPath)
+	if owners == nil {
+		return nil
+	}
+
+	return &YAMLChangeInfo{
+		FilePath:        change.NewPath,
+		FileType:        "developers",
+		DataProduct:     *dp,
+		OwnersApprovers: owners,
+		IsNewFile:       change.NewFile,
+	}
+}
+
+// parseGroupYAML parses a groups/*.yaml change
+func (r *CODEOWNERSSyncRule) parseGroupYAML(mrCtx *shared.MRContext, change gitlab.FileChange) *YAMLChangeInfo {
+	if !strings.Contains(change.NewPath, "/groups/") ||
+		!strings.HasPrefix(change.NewPath, "dataproducts/") ||
+		(!strings.HasSuffix(change.NewPath, ".yaml") && !strings.HasSuffix(change.NewPath, ".yml")) {
+		return nil
+	}
+
+	dp := r.extractDataProductInfo(change.NewPath)
+	if dp == nil {
+		return nil
+	}
+
+	groupInfo := r.fetchGroupInfo(mrCtx, change.NewPath)
+	if groupInfo == nil {
+		return nil
+	}
+
+	return &YAMLChangeInfo{
+		FilePath:        change.NewPath,
+		FileType:        "group",
+		DataProduct:     *dp,
+		OwnersApprovers: groupInfo.Approvers,
+		IsNewFile:       change.NewFile,
+		GroupName:       groupInfo.GroupName,
+	}
+}
+
+// extractDataProductInfo extracts data product info from file path
+func (r *CODEOWNERSSyncRule) extractDataProductInfo(filePath string) *DataProductInfo {
+	parts := strings.Split(filePath, "/")
+	if len(parts) < 3 || parts[0] != "dataproducts" {
+		return nil
+	}
+
+	dpType := parts[1]
+	if dpType != "aggregate" && dpType != "source" && dpType != "platform" {
+		return nil
+	}
+
+	return &DataProductInfo{
+		Type: dpType,
+		Name: parts[2],
+		Path: strings.Join(parts[:3], "/"),
+	}
+}
+
+// fetchOwners fetches owners from developers.yaml
+func (r *CODEOWNERSSyncRule) fetchOwners(mrCtx *shared.MRContext, filePath string) []string {
+	if r.client == nil || mrCtx.MRInfo == nil {
+		return nil
+	}
+
+	content, err := r.client.FetchFileContent(mrCtx.ProjectID, filePath, mrCtx.MRInfo.SourceBranch)
+	if err != nil {
+		logging.Warn("Failed to fetch developers.yaml: %v", err)
+		return nil
+	}
+
+	var data DevelopersYAML
+	if err := yaml.Unmarshal([]byte(content.Content), &data); err != nil {
+		logging.Warn("Failed to parse developers.yaml: %v", err)
+		return nil
+	}
+	return data.Group.Owners
+}
+
+// fetchGroupInfo fetches group info from groups/*.yaml
+func (r *CODEOWNERSSyncRule) fetchGroupInfo(mrCtx *shared.MRContext, filePath string) *GroupYAML {
+	if r.client == nil || mrCtx.MRInfo == nil {
+		return nil
+	}
+
+	content, err := r.client.FetchFileContent(mrCtx.ProjectID, filePath, mrCtx.MRInfo.SourceBranch)
+	if err != nil {
+		logging.Warn("Failed to fetch group YAML: %v", err)
+		return nil
+	}
+
+	var data GroupYAML
+	if err := yaml.Unmarshal([]byte(content.Content), &data); err != nil {
+		logging.Warn("Failed to parse group YAML: %v", err)
+		return nil
+	}
+	return &data
+}
+
+// dataProductExists checks if data product exists in base branch
+func (r *CODEOWNERSSyncRule) dataProductExists(mrCtx *shared.MRContext, dp DataProductInfo) bool {
+	if r.client == nil || mrCtx.MRInfo == nil {
+		return false
+	}
+	_, err := r.client.FetchFileContent(mrCtx.ProjectID, dp.Path+"/developers.yaml", mrCtx.MRInfo.TargetBranch)
+	return err == nil
+}
+
+// parseAddedCODEOWNERSEntries parses added entries from CODEOWNERS diff
+func (r *CODEOWNERSSyncRule) parseAddedCODEOWNERSEntries(mrCtx *shared.MRContext, filePath string) []CODEOWNERSEntry {
+	var entries []CODEOWNERSEntry
+
+	for _, change := range mrCtx.Changes {
+		if change.NewPath != filePath {
+			continue
+		}
+
+		for _, line := range strings.Split(change.Diff, "\n") {
+			if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "++") {
+				if entry := r.parseCODEOWNERSLine(strings.TrimPrefix(line, "+")); entry != nil {
+					entries = append(entries, *entry)
+				}
+			}
+		}
+		break
+	}
+	return entries
+}
+
+// parseCODEOWNERSLine parses a single CODEOWNERS line
+func (r *CODEOWNERSSyncRule) parseCODEOWNERSLine(line string) *CODEOWNERSEntry {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "[") {
+		return nil
+	}
+
+	parts := strings.Fields(line)
+	if len(parts) < 2 {
+		return nil
+	}
+
+	var owners []string
+	for _, part := range parts[1:] {
+		if strings.HasPrefix(part, "@") {
+			owner := strings.TrimPrefix(part, "@")
+			// Skip GitLab group references (e.g., @dataverse/dataverse-groups/...)
+			// These are added by update-codeowners.py script automatically
+			// We only validate individual user owners from YAML files
+			if !strings.Contains(owner, "/") {
+				owners = append(owners, owner)
+			}
+		}
+	}
+
+	if len(owners) == 0 {
+		return nil
+	}
+	return &CODEOWNERSEntry{Path: parts[0], Owners: owners}
+}
+
+// buildExpectedEntries builds expected CODEOWNERS entries from YAML changes
+func (r *CODEOWNERSSyncRule) buildExpectedEntries(yamlChanges []YAMLChangeInfo) []CODEOWNERSEntry {
+	var entries []CODEOWNERSEntry
+
+	for _, change := range yamlChanges {
+		switch change.FileType {
+		case "developers":
+			entries = append(entries, CODEOWNERSEntry{
+				Path:   "/" + change.DataProduct.Path + "/",
+				Owners: change.OwnersApprovers,
+			})
+		case "group":
+			entries = append(entries, CODEOWNERSEntry{
+				Path:   "/" + change.FilePath,
+				Owners: change.OwnersApprovers,
+			})
+			if change.GroupName != "" {
+				entries = append(entries, CODEOWNERSEntry{
+					Path:   "/" + change.DataProduct.Path + "/access-requests/groups/" + change.GroupName + "/",
+					Owners: change.OwnersApprovers,
+				})
+			}
+		}
+	}
+	return entries
+}
+
+// validateEntriesMatch validates that expected entries match added entries
+func (r *CODEOWNERSSyncRule) validateEntriesMatch(expected, added []CODEOWNERSEntry) string {
+	matched := make(map[int]bool)
+
+	// Check each expected entry exists in added
+	for _, exp := range expected {
+		found := false
+		for i, add := range added {
+			if r.entriesMatch(exp, add) {
+				found = true
+				matched[i] = true
+				break
+			}
+		}
+		if !found {
+			return "Missing CODEOWNERS entry for: " + exp.Path
+		}
+	}
+
+	// Check for extra data product entries
+	for i, add := range added {
+		if !matched[i] && strings.HasPrefix(add.Path, "/dataproducts/") {
+			return "Unexpected CODEOWNERS entry: " + add.Path
+		}
+	}
+
+	return ""
+}
+
+// entriesMatch checks if two CODEOWNERS entries match
+func (r *CODEOWNERSSyncRule) entriesMatch(expected, actual CODEOWNERSEntry) bool {
+	if expected.Path != actual.Path {
+		return false
+	}
+
+	if len(expected.Owners) != len(actual.Owners) {
+		return false
+	}
+
+	expSorted := make([]string, len(expected.Owners))
+	actSorted := make([]string, len(actual.Owners))
+	copy(expSorted, expected.Owners)
+	copy(actSorted, actual.Owners)
+	sort.Strings(expSorted)
+	sort.Strings(actSorted)
+
+	for i := range expSorted {
+		if expSorted[i] != actSorted[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rules/codeowners/rule.go
+++ b/internal/rules/codeowners/rule.go
@@ -65,6 +65,11 @@ func (r *CODEOWNERSSyncRule) ValidateLines(filePath string, fileContent string, 
 		return r.CreateManualReviewResult(reason)
 	}
 
+	// Check for orphan deletions (deletions without corresponding additions)
+	if reason := r.checkOrphanDeletions(mrCtx, filePath); reason != "" {
+		return r.CreateManualReviewResult(reason)
+	}
+
 	return r.CreateApprovalResult("Auto-approved: CODEOWNERS changes match YAML changes")
 }
 
@@ -126,8 +131,8 @@ func (r *CODEOWNERSSyncRule) parseDevelopersYAML(mrCtx *shared.MRContext, change
 
 // parseGroupYAML parses a groups/*.yaml change
 func (r *CODEOWNERSSyncRule) parseGroupYAML(mrCtx *shared.MRContext, change gitlab.FileChange) *YAMLChangeInfo {
-	if !strings.Contains(change.NewPath, "/groups/") ||
-		!strings.HasPrefix(change.NewPath, "dataproducts/") ||
+	if !strings.HasPrefix(change.NewPath, "dataproducts/") ||
+		!strings.Contains(change.NewPath, "/groups/") ||
 		(!strings.HasSuffix(change.NewPath, ".yaml") && !strings.HasSuffix(change.NewPath, ".yml")) {
 		return nil
 	}
@@ -241,6 +246,42 @@ func (r *CODEOWNERSSyncRule) parseAddedCODEOWNERSEntries(mrCtx *shared.MRContext
 	return entries
 }
 
+// checkOrphanDeletions checks for CODEOWNERS deletions that don't have corresponding additions
+func (r *CODEOWNERSSyncRule) checkOrphanDeletions(mrCtx *shared.MRContext, filePath string) string {
+	addedPaths := make(map[string]bool)
+	var deletedPaths []string
+
+	for _, change := range mrCtx.Changes {
+		if change.NewPath != filePath {
+			continue
+		}
+
+		for _, line := range strings.Split(change.Diff, "\n") {
+			// Track added paths
+			if strings.HasPrefix(line, "+") && !strings.HasPrefix(line, "++") {
+				if entry := r.parseCODEOWNERSLine(strings.TrimPrefix(line, "+")); entry != nil {
+					addedPaths[entry.Path] = true
+				}
+			}
+			// Track deleted paths
+			if strings.HasPrefix(line, "-") && !strings.HasPrefix(line, "--") {
+				if entry := r.parseCODEOWNERSLine(strings.TrimPrefix(line, "-")); entry != nil {
+					deletedPaths = append(deletedPaths, entry.Path)
+				}
+			}
+		}
+		break
+	}
+
+	// Check for orphan deletions (deleted paths without corresponding additions)
+	for _, deletedPath := range deletedPaths {
+		if !addedPaths[deletedPath] {
+			return "Unrelated CODEOWNERS deletion requires manual review: " + deletedPath
+		}
+	}
+	return ""
+}
+
 // parseCODEOWNERSLine parses a single CODEOWNERS line
 func (r *CODEOWNERSSyncRule) parseCODEOWNERSLine(line string) *CODEOWNERSEntry {
 	line = strings.TrimSpace(line)
@@ -318,9 +359,9 @@ func (r *CODEOWNERSSyncRule) validateEntriesMatch(expected, added []CODEOWNERSEn
 		}
 	}
 
-	// Check for extra data product entries
+	// Check for any extra unmatched entries
 	for i, add := range added {
-		if !matched[i] && strings.HasPrefix(add.Path, "/dataproducts/") {
+		if !matched[i] {
 			return "Unexpected CODEOWNERS entry: " + add.Path
 		}
 	}

--- a/internal/rules/codeowners/rule_test.go
+++ b/internal/rules/codeowners/rule_test.go
@@ -1,0 +1,313 @@
+package codeowners
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/redhat-data-and-ai/naysayer/internal/gitlab"
+	"github.com/redhat-data-and-ai/naysayer/internal/rules/shared"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockGitLabClient implements gitlab.GitLabClient for testing
+type MockGitLabClient struct {
+	fileContents map[string]*gitlab.FileContent
+}
+
+func NewMockGitLabClient() *MockGitLabClient {
+	return &MockGitLabClient{fileContents: make(map[string]*gitlab.FileContent)}
+}
+
+func (m *MockGitLabClient) FetchFileContent(projectID int, filePath, ref string) (*gitlab.FileContent, error) {
+	key := ref + ":" + filePath
+	if content, exists := m.fileContents[key]; exists {
+		return content, nil
+	}
+	return nil, fmt.Errorf("file not found: %s", filePath)
+}
+
+func (m *MockGitLabClient) SetFileContent(ref, filePath, content string) {
+	m.fileContents[ref+":"+filePath] = &gitlab.FileContent{
+		FileName: filePath, FilePath: filePath, Content: content, Encoding: "text", Ref: ref,
+	}
+}
+
+// Stub interface methods
+func (m *MockGitLabClient) FetchMRChanges(projectID, mrIID int) ([]gitlab.FileChange, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) AddMRComment(projectID, mrIID int, comment string) error { return nil }
+func (m *MockGitLabClient) ApproveMR(projectID, mrIID int) error                    { return nil }
+func (m *MockGitLabClient) ApproveMRWithMessage(projectID, mrIID int, message string) error {
+	return nil
+}
+func (m *MockGitLabClient) ResetNaysayerApproval(projectID, mrIID int) error { return nil }
+func (m *MockGitLabClient) GetMRTargetBranch(projectID, mrIID int) (string, error) {
+	return "main", nil
+}
+func (m *MockGitLabClient) GetMRDetails(projectID, mrIID int) (*gitlab.MRDetails, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) ListMRComments(projectID, mrIID int) ([]gitlab.MRComment, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) UpdateMRComment(projectID, mrIID, commentID int, newBody string) error {
+	return nil
+}
+func (m *MockGitLabClient) AddOrUpdateMRComment(projectID, mrIID int, commentBody, commentType string) error {
+	return nil
+}
+func (m *MockGitLabClient) FindLatestNaysayerComment(projectID, mrIID int, commentType ...string) (*gitlab.MRComment, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) GetCurrentBotUsername() (string, error)                 { return "", nil }
+func (m *MockGitLabClient) IsNaysayerBotAuthor(author map[string]interface{}) bool { return false }
+func (m *MockGitLabClient) RebaseMR(projectID, mrIID int) (bool, error)            { return false, nil }
+func (m *MockGitLabClient) CompareBranches(sourceProjectID int, sourceBranch string, targetProjectID int, targetBranch string) (*gitlab.CompareResult, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) GetBranchCommit(projectID int, branch string) (string, error) {
+	return "", nil
+}
+func (m *MockGitLabClient) CompareCommits(projectID int, fromSHA, toSHA string) (*gitlab.CompareResult, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) ListOpenMRs(projectID int) ([]int, error) { return nil, nil }
+func (m *MockGitLabClient) ListOpenMRsWithDetails(projectID int) ([]gitlab.MRDetails, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) ListAllOpenMRsWithDetails(projectID int) ([]gitlab.MRDetails, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) CloseMR(projectID, mrIID int) error { return nil }
+func (m *MockGitLabClient) GetPipelineJobs(projectID, pipelineID int) ([]gitlab.PipelineJob, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) GetJobTrace(projectID, jobID int) (string, error) { return "", nil }
+func (m *MockGitLabClient) FindLatestAtlantisComment(projectID, mrIID int) (*gitlab.MRComment, error) {
+	return nil, nil
+}
+func (m *MockGitLabClient) AreAllPipelineJobsSucceeded(projectID, pipelineID int) (bool, error) {
+	return false, nil
+}
+func (m *MockGitLabClient) CheckAtlantisCommentForPlanFailures(projectID, mrIID int) (bool, string) {
+	return false, ""
+}
+func (m *MockGitLabClient) FindCommentByPattern(projectID, mrIID int, pattern string) (bool, error) {
+	return false, nil
+}
+
+func TestCODEOWNERSSyncRule_isCODEOWNERSFile(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(nil)
+
+	tests := []struct {
+		filePath string
+		expected bool
+	}{
+		{"CODEOWNERS", true},
+		{"codeowners", true},
+		{".github/CODEOWNERS", true},
+		{"README.md", false},
+		{"developers.yaml", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filePath, func(t *testing.T) {
+			assert.Equal(t, tt.expected, rule.isCODEOWNERSFile(tt.filePath))
+		})
+	}
+}
+
+func TestCODEOWNERSSyncRule_extractDataProductInfo(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(nil)
+
+	tests := []struct {
+		filePath string
+		expected *DataProductInfo
+	}{
+		{"dataproducts/aggregate/bookingsmaster/developers.yaml", &DataProductInfo{Type: "aggregate", Name: "bookingsmaster", Path: "dataproducts/aggregate/bookingsmaster"}},
+		{"dataproducts/source/marketo/groups/foo.yaml", &DataProductInfo{Type: "source", Name: "marketo", Path: "dataproducts/source/marketo"}},
+		{"other/path/file.yaml", nil},
+		{"dataproducts/invalid/test/file.yaml", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filePath, func(t *testing.T) {
+			result := rule.extractDataProductInfo(tt.filePath)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, tt.expected.Type, result.Type)
+				assert.Equal(t, tt.expected.Name, result.Name)
+				assert.Equal(t, tt.expected.Path, result.Path)
+			}
+		})
+	}
+}
+
+func TestCODEOWNERSSyncRule_parseCODEOWNERSLine(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(nil)
+
+	tests := []struct {
+		line     string
+		expected *CODEOWNERSEntry
+	}{
+		{"/dataproducts/aggregate/bookingsmaster/ @alice @bob", &CODEOWNERSEntry{Path: "/dataproducts/aggregate/bookingsmaster/", Owners: []string{"alice", "bob"}}},
+		{"# Comment", nil},
+		{"[Section]", nil},
+		{"", nil},
+		{"* @dataverse/dataverse-groups/maintainers", nil}, // Group refs skipped
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.line, func(t *testing.T) {
+			result := rule.parseCODEOWNERSLine(tt.line)
+			if tt.expected == nil {
+				assert.Nil(t, result)
+			} else {
+				assert.Equal(t, tt.expected.Path, result.Path)
+				assert.ElementsMatch(t, tt.expected.Owners, result.Owners)
+			}
+		})
+	}
+}
+
+func TestCODEOWNERSSyncRule_entriesMatch(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(nil)
+
+	tests := []struct {
+		name     string
+		expected CODEOWNERSEntry
+		actual   CODEOWNERSEntry
+		match    bool
+	}{
+		{"exact", CODEOWNERSEntry{"/path/", []string{"a", "b"}}, CODEOWNERSEntry{"/path/", []string{"a", "b"}}, true},
+		{"reordered", CODEOWNERSEntry{"/path/", []string{"a", "b"}}, CODEOWNERSEntry{"/path/", []string{"b", "a"}}, true},
+		{"diff path", CODEOWNERSEntry{"/path1/", []string{"a"}}, CODEOWNERSEntry{"/path2/", []string{"a"}}, false},
+		{"diff owners", CODEOWNERSEntry{"/path/", []string{"a"}}, CODEOWNERSEntry{"/path/", []string{"b"}}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.match, rule.entriesMatch(tt.expected, tt.actual))
+		})
+	}
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_NotCODEOWNERS(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(nil)
+	decision, reason := rule.ValidateLines("README.md", "", nil)
+	assert.Equal(t, shared.Approve, decision)
+	assert.Contains(t, reason, "Not a CODEOWNERS file")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_NoMRContext(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(nil)
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.ManualReview, decision)
+	assert.Contains(t, reason, "MR context not available")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_NoYAMLChanges(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(NewMockGitLabClient())
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{{NewPath: "CODEOWNERS", Diff: "+/path/ @user"}},
+		MRInfo:  &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.ManualReview, decision)
+	assert.Contains(t, reason, "without corresponding YAML changes")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_NewDataProduct(t *testing.T) {
+	mock := NewMockGitLabClient()
+	mock.SetFileContent("feature", "dataproducts/aggregate/new/developers.yaml", "group:\n  owners: [alice]")
+
+	rule := NewCODEOWNERSSyncRule(mock)
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{
+			{NewPath: "CODEOWNERS", Diff: "+/dataproducts/aggregate/new/ @alice"},
+			{NewPath: "dataproducts/aggregate/new/developers.yaml", NewFile: true},
+		},
+		MRInfo: &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.ManualReview, decision)
+	assert.Contains(t, reason, "New data product")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_ExistingDataProductUpdate(t *testing.T) {
+	mock := NewMockGitLabClient()
+	mock.SetFileContent("feature", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners:\n    - alice\n    - bob")
+	mock.SetFileContent("main", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners: [alice]")
+
+	rule := NewCODEOWNERSSyncRule(mock)
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{
+			{NewPath: "CODEOWNERS", Diff: "+/dataproducts/aggregate/dp/ @alice @bob"},
+			{NewPath: "dataproducts/aggregate/dp/developers.yaml", NewFile: false},
+		},
+		MRInfo: &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.Approve, decision)
+	assert.Contains(t, reason, "Auto-approved")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_NewGroupInExistingDP(t *testing.T) {
+	mock := NewMockGitLabClient()
+	mock.SetFileContent("feature", "dataproducts/aggregate/dp/groups/grp.yaml", "group_name: grp\napprovers:\n  - approver1")
+	mock.SetFileContent("main", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners: [alice]")
+
+	rule := NewCODEOWNERSSyncRule(mock)
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{
+			{NewPath: "CODEOWNERS", Diff: "+/dataproducts/aggregate/dp/groups/grp.yaml @approver1\n+/dataproducts/aggregate/dp/access-requests/groups/grp/ @approver1"},
+			{NewPath: "dataproducts/aggregate/dp/groups/grp.yaml", NewFile: true},
+		},
+		MRInfo: &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.Approve, decision)
+	assert.Contains(t, reason, "Auto-approved")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_NewGroupInNewDP(t *testing.T) {
+	mock := NewMockGitLabClient()
+	mock.SetFileContent("feature", "dataproducts/aggregate/new/groups/grp.yaml", "group_name: grp\napprovers: [a]")
+	// No developers.yaml in main - new data product
+
+	rule := NewCODEOWNERSSyncRule(mock)
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{
+			{NewPath: "CODEOWNERS", Diff: "+/path/ @a"},
+			{NewPath: "dataproducts/aggregate/new/groups/grp.yaml", NewFile: true},
+		},
+		MRInfo: &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.ManualReview, decision)
+	assert.Contains(t, reason, "New group in new data product")
+}
+
+func TestCODEOWNERSSyncRule_GetCoveredLines(t *testing.T) {
+	rule := NewCODEOWNERSSyncRule(nil)
+
+	result := rule.GetCoveredLines("CODEOWNERS", "line1\nline2\nline3")
+	assert.Len(t, result, 1)
+	assert.Equal(t, 1, result[0].StartLine)
+	assert.Equal(t, 3, result[0].EndLine)
+
+	result = rule.GetCoveredLines("README.md", "# README")
+	assert.Len(t, result, 0)
+}

--- a/internal/rules/codeowners/rule_test.go
+++ b/internal/rules/codeowners/rule_test.go
@@ -300,6 +300,66 @@ func TestCODEOWNERSSyncRule_ValidateLines_NewGroupInNewDP(t *testing.T) {
 	assert.Contains(t, reason, "New group in new data product")
 }
 
+func TestCODEOWNERSSyncRule_ValidateLines_ExtraUnexpectedEntry(t *testing.T) {
+	mock := NewMockGitLabClient()
+	mock.SetFileContent("feature", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners:\n    - alice\n    - bob")
+	mock.SetFileContent("main", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners: [old]")
+
+	rule := NewCODEOWNERSSyncRule(mock)
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{
+			{NewPath: "CODEOWNERS", Diff: "+/dataproducts/aggregate/dp/ @alice @bob\n+* @mallory"},
+			{NewPath: "dataproducts/aggregate/dp/developers.yaml", NewFile: false},
+		},
+		MRInfo: &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.ManualReview, decision)
+	assert.Contains(t, reason, "Unexpected CODEOWNERS entry")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_OrphanDeletion(t *testing.T) {
+	mock := NewMockGitLabClient()
+	mock.SetFileContent("feature", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners:\n    - alice\n    - bob")
+	mock.SetFileContent("main", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners: [old]")
+
+	rule := NewCODEOWNERSSyncRule(mock)
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{
+			{NewPath: "CODEOWNERS", Diff: "+/dataproducts/aggregate/dp/ @alice @bob\n-/serviceaccounts/ @platformadmin"},
+			{NewPath: "dataproducts/aggregate/dp/developers.yaml", NewFile: false},
+		},
+		MRInfo: &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.ManualReview, decision)
+	assert.Contains(t, reason, "Unrelated CODEOWNERS deletion")
+}
+
+func TestCODEOWNERSSyncRule_ValidateLines_ValidModification(t *testing.T) {
+	mock := NewMockGitLabClient()
+	mock.SetFileContent("feature", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners:\n    - bob")
+	mock.SetFileContent("main", "dataproducts/aggregate/dp/developers.yaml", "group:\n  owners: [alice, bob]")
+
+	rule := NewCODEOWNERSSyncRule(mock)
+	rule.SetMRContext(&shared.MRContext{
+		ProjectID: 1, MRIID: 1,
+		Changes: []gitlab.FileChange{
+			{NewPath: "CODEOWNERS", Diff: "-/dataproducts/aggregate/dp/ @alice @bob\n+/dataproducts/aggregate/dp/ @bob"},
+			{NewPath: "dataproducts/aggregate/dp/developers.yaml", NewFile: false},
+		},
+		MRInfo: &gitlab.MRInfo{SourceBranch: "feature", TargetBranch: "main"},
+	})
+
+	decision, reason := rule.ValidateLines("CODEOWNERS", "", nil)
+	assert.Equal(t, shared.Approve, decision)
+	assert.Contains(t, reason, "Auto-approved")
+}
+
 func TestCODEOWNERSSyncRule_GetCoveredLines(t *testing.T) {
 	rule := NewCODEOWNERSSyncRule(nil)
 

--- a/internal/rules/codeowners/types.go
+++ b/internal/rules/codeowners/types.go
@@ -1,0 +1,37 @@
+package codeowners
+
+// DevelopersYAML represents the structure of developers.yaml
+type DevelopersYAML struct {
+	Group struct {
+		Owners []string `yaml:"owners"`
+	} `yaml:"group"`
+}
+
+// GroupYAML represents the structure of groups/*.yaml files
+type GroupYAML struct {
+	GroupName string   `yaml:"group_name"`
+	Approvers []string `yaml:"approvers"`
+}
+
+// DataProductInfo contains information about a data product extracted from file paths
+type DataProductInfo struct {
+	Type string // "aggregate", "source", or "platform"
+	Name string // e.g., "bookingsmaster"
+	Path string // Full path e.g., "dataproducts/aggregate/bookingsmaster"
+}
+
+// YAMLChangeInfo contains information about a changed YAML file
+type YAMLChangeInfo struct {
+	FilePath        string
+	FileType        string // "developers" or "group"
+	DataProduct     DataProductInfo
+	OwnersApprovers []string
+	IsNewFile       bool
+	GroupName       string // Only for groups/*.yaml
+}
+
+// CODEOWNERSEntry represents a parsed CODEOWNERS entry
+type CODEOWNERSEntry struct {
+	Path   string
+	Owners []string
+}

--- a/internal/rules/registry.go
+++ b/internal/rules/registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/redhat-data-and-ai/naysayer/internal/config"
 	"github.com/redhat-data-and-ai/naysayer/internal/gitlab"
 	"github.com/redhat-data-and-ai/naysayer/internal/logging"
+	"github.com/redhat-data-and-ai/naysayer/internal/rules/codeowners"
 	"github.com/redhat-data-and-ai/naysayer/internal/rules/common"
 	"github.com/redhat-data-and-ai/naysayer/internal/rules/dataproduct_consumer"
 	"github.com/redhat-data-and-ai/naysayer/internal/rules/shared"
@@ -108,6 +109,18 @@ func (r *RuleRegistry) registerBuiltInRules() {
 		},
 		Enabled:  true,
 		Category: "consumer_access",
+	})
+
+	// CODEOWNERS sync rule
+	_ = r.RegisterRule(&RuleInfo{
+		Name:        "codeowners_sync_rule",
+		Description: "Auto-approves CODEOWNERS changes that match developers.yaml or groups/*.yaml changes in the same MR",
+		Version:     "1.0.0",
+		Factory: func(client gitlab.GitLabClient) shared.Rule {
+			return codeowners.NewCODEOWNERSSyncRule(client)
+		},
+		Enabled:  true,
+		Category: "codeowners",
 	})
 
 }

--- a/rules.yaml
+++ b/rules.yaml
@@ -125,6 +125,20 @@ files:
             enabled: true
         auto_approve: true
 
+  # Group configuration files - Low risk, can auto-approve
+  - name: "group_configs"
+    path: "dataproducts/**/groups/"
+    filename: "*.{yaml,yml}"
+    parser_type: yaml
+    enabled: true
+    sections:
+      - name: full_file
+        yaml_path: .
+        rule_configs:
+          - name: metadata_rule
+            enabled: true
+        auto_approve: true
+
   # Masking files - Low risk, can auto-approve
   - name: "masking_files"
     path: "dataproducts/**/"
@@ -136,6 +150,20 @@ files:
         yaml_path: .
         rule_configs:
           - name: metadata_rule
+            enabled: true
+        auto_approve: true
+
+  # CODEOWNERS file - Auto-approve when synced with developers.yaml or groups/*.yaml
+  - name: "codeowners_file"
+    path: "**/"
+    filename: "CODEOWNERS"
+    parser_type: yaml
+    enabled: true
+    sections:
+      - name: codeowners_sync_validation
+        yaml_path: .
+        rule_configs:
+          - name: codeowners_sync_rule
             enabled: true
         auto_approve: true
 


### PR DESCRIPTION
## Description

Brief description of what this PR does.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement
- [ ] 🔨 Build/CI changes

## Related Issues

Fixes #(issue number)

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual testing completed
- [ ] Coverage maintained or improved
