### PR TITLE
Upgrade Go to 1.25.8 to fix security vulnerabilities

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24.13'
+        go-version: '1.25.8'
         cache: true
 
     - name: Cache Go modules
@@ -86,7 +86,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24.13'
+        go-version: '1.25.8'
 
     - name: Run Gosec Security Scanner
       run: |
@@ -119,7 +119,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24.13'
+        go-version: '1.25.8'
         cache: true
 
     - name: Cache Go modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ FROM registry.access.redhat.com/ubi9/ubi-minimal:latest AS builder
 RUN microdnf install -y tar gzip ca-certificates
 
 # Install Go
-RUN curl -OL https://go.dev/dl/go1.24.13.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.24.13.linux-amd64.tar.gz
+RUN curl -OL https://go.dev/dl/go1.25.8.linux-amd64.tar.gz && \
+    tar -C /usr/local -xzf go1.25.8.linux-amd64.tar.gz
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-data-and-ai/naysayer
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/gofiber/fiber/v2 v2.52.12


### PR DESCRIPTION
Upgrade Go to 1.25.8 to fix security vulnerabilities GO-2026-4601 and GO-2026-4602

## Description

Brief description of what this PR does.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement
- [ ] 🔨 Build/CI changes

## Related Issues

Fixes #(issue number)

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual testing completed
- [ ] Coverage maintained or improved
