### PR TITLE
DATA-7484 Disable groups rule check

### DIFF
--- a/e2e/scenario_loader.go
+++ b/e2e/scenario_loader.go
@@ -225,6 +225,8 @@ func parseDecisionType(decision string) shared.DecisionType {
 		return shared.Approve
 	case "manualreview", "manual_review", "manual-review", "manual review":
 		return shared.ManualReview
+	case "commentonly", "comment_only", "comment-only", "comment only":
+		return shared.CommentOnly
 	default:
 		return shared.ManualReview // Default to safe option
 	}

--- a/e2e/testdata/scenarios/44_ignored_files_only/after/dataproducts/source/analytics/groups/consumer-a.yaml
+++ b/e2e/testdata/scenarios/44_ignored_files_only/after/dataproducts/source/analytics/groups/consumer-a.yaml
@@ -1,0 +1,3 @@
+---
+name: consumer-a
+source: analytics

--- a/e2e/testdata/scenarios/44_ignored_files_only/scenario.yaml
+++ b/e2e/testdata/scenarios/44_ignored_files_only/scenario.yaml
@@ -1,0 +1,18 @@
+name: "All files ignored — comment only, no decision"
+description: "When all changed files match ignore_files patterns, naysayer posts a comment but makes no approval decision"
+
+expected:
+  decision: CommentOnly
+  reason: "All changed files are in the ignore list"
+  approved: false
+
+  comment_contains:
+    - "All files ignored"
+    - "**Ignored files**"
+    - "consumer-a.yaml"
+
+mr_metadata:
+  title: "Add consumer group config"
+  author: "testuser"
+  source_branch: "feature/add-consumer-group"
+  target_branch: "main"

--- a/e2e/testdata/scenarios/45_ignored_plus_validated_files/after/dataproducts/source/analytics/groups/consumer-a.yaml
+++ b/e2e/testdata/scenarios/45_ignored_plus_validated_files/after/dataproducts/source/analytics/groups/consumer-a.yaml
@@ -1,0 +1,3 @@
+---
+name: consumer-a
+source: analytics

--- a/e2e/testdata/scenarios/45_ignored_plus_validated_files/after/dataproducts/source/analytics/product.yaml
+++ b/e2e/testdata/scenarios/45_ignored_plus_validated_files/after/dataproducts/source/analytics/product.yaml
@@ -1,0 +1,7 @@
+---
+name: analytics-v2
+kind: source-aligned
+rover_group: example-analytics
+tags:
+  data_product: analytics
+  pii: true

--- a/e2e/testdata/scenarios/45_ignored_plus_validated_files/before/dataproducts/source/analytics/product.yaml
+++ b/e2e/testdata/scenarios/45_ignored_plus_validated_files/before/dataproducts/source/analytics/product.yaml
@@ -1,0 +1,6 @@
+---
+name: analytics
+kind: source-aligned
+rover_group: example-analytics
+tags:
+  data_product: analytics

--- a/e2e/testdata/scenarios/45_ignored_plus_validated_files/scenario.yaml
+++ b/e2e/testdata/scenarios/45_ignored_plus_validated_files/scenario.yaml
@@ -1,0 +1,18 @@
+name: "Ignored file plus validated file — ignored file does not block approval"
+description: "When an MR has both an ignored file (group config) and a validated file (product.yaml with metadata change), the ignored file is skipped and the MR can still be auto-approved"
+
+expected:
+  decision: Approve
+  reason: "All files passed validation"
+  approved: true
+
+  comment_contains:
+    - "✅ **Auto-approved**"
+    - "**Ignored files**"
+    - "consumer-a.yaml"
+
+mr_metadata:
+  title: "Add consumer group and update product metadata"
+  author: "testuser"
+  source_branch: "feature/group-and-metadata"
+  target_branch: "main"

--- a/internal/config/sections.go
+++ b/internal/config/sections.go
@@ -37,16 +37,25 @@ type FileRuleConfig struct {
 	Sections      []SectionDefinition `yaml:"sections"`       // Sections within this file type
 }
 
+// IgnoreFileConfig defines a file pattern to be completely skipped from rule evaluation
+type IgnoreFileConfig struct {
+	Name     string `yaml:"name"`
+	Path     string `yaml:"path"`
+	Filename string `yaml:"filename"`
+}
+
 // GlobalRuleConfig holds the complete rule configuration for all file types
 type GlobalRuleConfig struct {
-	Enabled bool             `yaml:"enabled"`
-	Files   []FileRuleConfig `yaml:"files"` // Array of file configurations
+	Enabled     bool               `yaml:"enabled"`
+	Files       []FileRuleConfig   `yaml:"files"`         // Array of file configurations
+	IgnoreFiles []IgnoreFileConfig `yaml:"ignore_files"`  // File patterns to skip from evaluation
 }
 
 // RuleBasedConfig is the external YAML format for rule configuration
 type RuleBasedConfig struct {
-	Enabled bool             `yaml:"enabled"`
-	Files   []FileRuleConfig `yaml:"files"` // Array of file configurations
+	Enabled     bool               `yaml:"enabled"`
+	Files       []FileRuleConfig   `yaml:"files"`        // Array of file configurations
+	IgnoreFiles []IgnoreFileConfig `yaml:"ignore_files"` // File patterns to skip from evaluation
 }
 
 // LoadRuleConfig loads rule-based validation configuration from YAML
@@ -77,8 +86,9 @@ func LoadRuleConfig(configPath string) (*GlobalRuleConfig, error) {
 
 	// Convert YAML config to internal format
 	config := &GlobalRuleConfig{
-		Enabled: yamlConfig.Enabled,
-		Files:   yamlConfig.Files,
+		Enabled:     yamlConfig.Enabled,
+		Files:       yamlConfig.Files,
+		IgnoreFiles: yamlConfig.IgnoreFiles,
 	}
 
 	// Validate the configuration
@@ -93,8 +103,9 @@ func LoadRuleConfig(configPath string) (*GlobalRuleConfig, error) {
 func SaveRuleConfig(config *GlobalRuleConfig, configPath string) error {
 	// Convert internal config to external format
 	externalConfig := RuleBasedConfig{
-		Enabled: config.Enabled,
-		Files:   config.Files,
+		Enabled:     config.Enabled,
+		Files:       config.Files,
+		IgnoreFiles: config.IgnoreFiles,
 	}
 
 	// Marshal to YAML

--- a/internal/rules/manager.go
+++ b/internal/rules/manager.go
@@ -19,6 +19,7 @@ type SectionRuleManager struct {
 	config         *config.GlobalRuleConfig
 	ruleRegistry   map[string]shared.Rule // Rule name -> rule instance
 	gitlabClient   gitlab.GitLabClient    // GitLab client for fetching file content
+	ignorePatterns []string               // Compiled patterns from ignore_files config
 }
 
 // NewSectionRuleManager creates a new section-based rule manager
@@ -67,6 +68,13 @@ func (srm *SectionRuleManager) initializeParsers() {
 			logging.Warn("Unknown parser type %s for file configuration: %s", fileConfig.ParserType, fileConfig.Name)
 		}
 	}
+
+	// Initialize ignore patterns from ignore_files configuration
+	for _, ignoreConfig := range srm.config.IgnoreFiles {
+		pattern := ignoreConfig.Path + ignoreConfig.Filename
+		srm.ignorePatterns = append(srm.ignorePatterns, pattern)
+		logging.Info("Registered ignore pattern: %s (%s)", pattern, ignoreConfig.Name)
+	}
 }
 
 // AddRule registers a rule with the manager
@@ -98,7 +106,7 @@ func (srm *SectionRuleManager) EvaluateAll(mrCtx *shared.MRContext) *shared.Rule
 	srm.setMRContextForRules(mrCtx)
 
 	// Perform section-based validation
-	fileValidations, overallDecision := srm.validateFilesWithSections(mrCtx)
+	fileValidations, overallDecision, ignoredFiles := srm.validateFilesWithSections(mrCtx)
 
 	// Calculate summary statistics
 	totalFiles := len(fileValidations)
@@ -127,12 +135,14 @@ func (srm *SectionRuleManager) EvaluateAll(mrCtx *shared.MRContext) *shared.Rule
 		ApprovedFiles:   approvedFiles,
 		ReviewFiles:     reviewFiles,
 		UncoveredFiles:  uncoveredFiles,
+		IgnoredFiles:    ignoredFiles,
 	}
 }
 
 // validateFilesWithSections performs section-based validation for each file
-func (srm *SectionRuleManager) validateFilesWithSections(mrCtx *shared.MRContext) (map[string]*shared.FileValidationSummary, shared.Decision) {
+func (srm *SectionRuleManager) validateFilesWithSections(mrCtx *shared.MRContext) (map[string]*shared.FileValidationSummary, shared.Decision, []string) {
 	fileValidations := make(map[string]*shared.FileValidationSummary)
+	var ignoredFiles []string
 
 	// Get unique file paths from changes
 	filePaths := srm.getUniqueFilePaths(mrCtx.Changes)
@@ -141,6 +151,13 @@ func (srm *SectionRuleManager) validateFilesWithSections(mrCtx *shared.MRContext
 	sourceProjectID := srm.sourceProjectIDForMR(mrCtx)
 
 	for _, filePath := range filePaths {
+		// Check ignore patterns first (takes precedence over all other classification)
+		if srm.isIgnoredFile(filePath) {
+			logging.Info("File ignored by configuration: %s", filePath)
+			ignoredFiles = append(ignoredFiles, filePath)
+			continue
+		}
+
 		// Check if file was deleted in this MR
 		if srm.isDeletedFile(filePath, mrCtx.Changes) {
 			reason := srm.getDeletionReason(filePath)
@@ -178,8 +195,8 @@ func (srm *SectionRuleManager) validateFilesWithSections(mrCtx *shared.MRContext
 	}
 
 	// Determine overall decision
-	overallDecision := srm.determineOverallDecision(fileValidations)
-	return fileValidations, overallDecision
+	overallDecision := srm.determineOverallDecision(fileValidations, ignoredFiles)
+	return fileValidations, overallDecision, ignoredFiles
 }
 
 // getChangedLinesForFile extracts changed line ranges for a specific file from MR context
@@ -448,6 +465,16 @@ func (srm *SectionRuleManager) getParserForFile(filePath string) shared.SectionP
 		}
 	}
 	return nil
+}
+
+// isIgnoredFile checks if a file matches any ignore_files pattern
+func (srm *SectionRuleManager) isIgnoredFile(filePath string) bool {
+	for _, pattern := range srm.ignorePatterns {
+		if shared.MatchesPattern(filePath, pattern) {
+			return true
+		}
+	}
+	return false
 }
 
 // getEnabledRulesForSection returns enabled rules that apply to a specific section
@@ -760,10 +787,18 @@ func (srm *SectionRuleManager) sectionsOverlap(section shared.Section, changedRa
 	return section.StartLine <= changedRange.EndLine && section.EndLine >= changedRange.StartLine
 }
 
-func (srm *SectionRuleManager) determineOverallDecision(fileValidations map[string]*shared.FileValidationSummary) shared.Decision {
-	// Safety check: if there are no file validations, require manual review
-	// This catches edge cases like net-zero changes that slip through earlier checks
+func (srm *SectionRuleManager) determineOverallDecision(fileValidations map[string]*shared.FileValidationSummary, ignoredFiles []string) shared.Decision {
+	// If there are no file validations, check if all files were ignored
 	if len(fileValidations) == 0 {
+		if len(ignoredFiles) > 0 {
+			logging.Info("All changed files are in the ignore list - posting comment only, no decision")
+			return shared.Decision{
+				Type:    shared.CommentOnly,
+				Reason:  "All changed files are in the ignore list - no decision made",
+				Summary: "ℹ️ All files ignored",
+				Details: fmt.Sprintf("All %d changed file(s) match ignore patterns. No validation performed, no approval decision made.", len(ignoredFiles)),
+			}
+		}
 		logging.Warn("No files to validate - requiring manual review for safety")
 		return shared.Decision{
 			Type:    shared.ManualReview,

--- a/internal/rules/manager_test.go
+++ b/internal/rules/manager_test.go
@@ -249,9 +249,9 @@ func TestSectionRuleManager_DetermineOverallDecision_ZeroFiles(t *testing.T) {
 
 	manager := NewSectionRuleManager(ruleConfig, nil)
 
-	// Test with empty file validations - should require manual review
+	// Test with empty file validations and no ignored files - should require manual review
 	emptyValidations := make(map[string]*shared.FileValidationSummary)
-	decision := manager.determineOverallDecision(emptyValidations)
+	decision := manager.determineOverallDecision(emptyValidations, nil)
 
 	assert.Equal(t, shared.ManualReview, decision.Type)
 	assert.Contains(t, decision.Reason, "no files to validate")
@@ -272,7 +272,7 @@ func TestSectionRuleManager_DetermineOverallDecision_WithFiles(t *testing.T) {
 			FileDecision: shared.Approve,
 		},
 	}
-	decision := manager.determineOverallDecision(approvedValidations)
+	decision := manager.determineOverallDecision(approvedValidations, nil)
 
 	assert.Equal(t, shared.Approve, decision.Type)
 
@@ -283,7 +283,7 @@ func TestSectionRuleManager_DetermineOverallDecision_WithFiles(t *testing.T) {
 			FileDecision: shared.ManualReview,
 		},
 	}
-	decision = manager.determineOverallDecision(reviewValidations)
+	decision = manager.determineOverallDecision(reviewValidations, nil)
 
 	assert.Equal(t, shared.ManualReview, decision.Type)
 }
@@ -678,4 +678,92 @@ func TestParseHunkHeader(t *testing.T) {
 			assert.Equal(t, tt.expected, result)
 		})
 	}
+}
+
+func TestIsIgnoredFile(t *testing.T) {
+	ruleConfig := &config.GlobalRuleConfig{
+		Files: []config.FileRuleConfig{},
+		IgnoreFiles: []config.IgnoreFileConfig{
+			{Name: "sql_migrations", Path: "**/", Filename: "*.sql"},
+			{Name: "ci_config", Path: "", Filename: ".gitlab-ci.yml"},
+			{Name: "gitkeep", Path: "**/", Filename: ".gitkeep"},
+		},
+	}
+
+	manager := NewSectionRuleManager(ruleConfig, nil)
+
+	tests := []struct {
+		name     string
+		filePath string
+		expected bool
+	}{
+		{"sql file at root", "migration.sql", true},
+		{"sql file nested", "dataproducts/source/analytics/migration.sql", true},
+		{"gitlab-ci at root", ".gitlab-ci.yml", true},
+		{"gitkeep nested", "dataproducts/source/.gitkeep", true},
+		{"gitkeep at root", ".gitkeep", true},
+		{"yaml file not ignored", "dataproducts/source/product.yaml", false},
+		{"markdown not ignored", "README.md", false},
+		{"python not ignored", "scripts/process.py", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := manager.isIgnoredFile(tt.filePath)
+			assert.Equal(t, tt.expected, result, "isIgnoredFile(%q)", tt.filePath)
+		})
+	}
+}
+
+func TestDetermineOverallDecision_AllIgnored(t *testing.T) {
+	ruleConfig := &config.GlobalRuleConfig{
+		Files: []config.FileRuleConfig{},
+	}
+
+	manager := NewSectionRuleManager(ruleConfig, nil)
+
+	// When all files are ignored and no file validations exist, decision is CommentOnly
+	emptyValidations := make(map[string]*shared.FileValidationSummary)
+	ignoredFiles := []string{"migration.sql", ".gitlab-ci.yml"}
+	decision := manager.determineOverallDecision(emptyValidations, ignoredFiles)
+
+	assert.Equal(t, shared.CommentOnly, decision.Type)
+	assert.Contains(t, decision.Reason, "ignore list")
+	assert.Contains(t, decision.Summary, "ignored")
+}
+
+func TestDetermineOverallDecision_SomeIgnoredSomeValidated(t *testing.T) {
+	ruleConfig := &config.GlobalRuleConfig{
+		Files: []config.FileRuleConfig{},
+	}
+
+	manager := NewSectionRuleManager(ruleConfig, nil)
+
+	// When some files are validated (approved) and some ignored, decision is based on validated files
+	validations := map[string]*shared.FileValidationSummary{
+		"product.yaml": {
+			FilePath:     "product.yaml",
+			FileDecision: shared.Approve,
+		},
+	}
+	ignoredFiles := []string{"migration.sql"}
+	decision := manager.determineOverallDecision(validations, ignoredFiles)
+
+	assert.Equal(t, shared.Approve, decision.Type)
+}
+
+func TestIgnorePatternInitialization(t *testing.T) {
+	ruleConfig := &config.GlobalRuleConfig{
+		Files: []config.FileRuleConfig{},
+		IgnoreFiles: []config.IgnoreFileConfig{
+			{Name: "sql_migrations", Path: "**/", Filename: "*.sql"},
+			{Name: "ci_config", Path: "", Filename: ".gitlab-ci.yml"},
+		},
+	}
+
+	manager := NewSectionRuleManager(ruleConfig, nil)
+
+	assert.Equal(t, 2, len(manager.ignorePatterns))
+	assert.Contains(t, manager.ignorePatterns, "**/*.sql")
+	assert.Contains(t, manager.ignorePatterns, ".gitlab-ci.yml")
 }

--- a/internal/rules/shared/types.go
+++ b/internal/rules/shared/types.go
@@ -14,6 +14,7 @@ type DecisionType string
 const (
 	Approve      DecisionType = "approve"       // Auto-approve the MR
 	ManualReview DecisionType = "manual_review" // Require manual approval
+	CommentOnly  DecisionType = "comment_only"  // Post informational comment, no MR action
 )
 
 // Decision represents a simplified approval decision for a merge request
@@ -113,6 +114,9 @@ type RuleEvaluation struct {
 	ApprovedFiles  int `json:"approved_files"`
 	ReviewFiles    int `json:"review_files"`
 	UncoveredFiles int `json:"uncovered_files"`
+
+	// Files skipped by ignore_files configuration
+	IgnoredFiles []string `json:"ignored_files,omitempty"`
 }
 
 // Common helper functions for rule evaluation

--- a/internal/webhook/dataverse_product_config_review.go
+++ b/internal/webhook/dataverse_product_config_review.go
@@ -272,6 +272,35 @@ func (h *DataProductConfigMrReviewHandler) handleManualReviewWithComments(result
 	return nil
 }
 
+// handleCommentOnlyWithComments posts an informational comment without approving or requesting review
+func (h *DataProductConfigMrReviewHandler) handleCommentOnlyWithComments(result *shared.RuleEvaluation, mrInfo *gitlab.MRInfo) error {
+	messageBuilder := NewMessageBuilder(h.config)
+
+	if h.config.Comments.EnableMRComments {
+		comment := messageBuilder.BuildCommentOnlyComment(result)
+
+		logging.MRInfo(mrInfo.MRIID, "Adding/updating comment-only message (no MR decision)")
+
+		if h.config.Comments.UpdateExistingComments {
+			if err := h.gitlabClient.AddOrUpdateMRComment(mrInfo.ProjectID, mrInfo.MRIID, comment, "comment-only"); err != nil {
+				logging.MRError(mrInfo.MRIID, "Failed to add/update comment-only message", err)
+				return err
+			}
+			logging.MRInfo(mrInfo.MRIID, "Added/updated comment-only message")
+		} else {
+			if err := h.gitlabClient.AddMRComment(mrInfo.ProjectID, mrInfo.MRIID, comment); err != nil {
+				logging.MRError(mrInfo.MRIID, "Failed to add comment-only message", err)
+				return err
+			}
+			logging.MRInfo(mrInfo.MRIID, "Added comment-only message")
+		}
+	} else {
+		logging.MRInfo(mrInfo.MRIID, "Skipping comment-only message (comments disabled)")
+	}
+
+	return nil
+}
+
 // handleMergeRequestEvent handles traditional MR events (immediate processing)
 func (h *DataProductConfigMrReviewHandler) handleMergeRequestEvent(c *fiber.Ctx, payload map[string]interface{}) error {
 	// simplified: Only process "open" and "update" actions. Other actions (approved, unapproved,
@@ -352,7 +381,8 @@ func (h *DataProductConfigMrReviewHandler) handleMergeRequestEvent(c *fiber.Ctx,
 
 	// Handle approval with comments if decision is to approve
 	approved := false
-	if result.FinalDecision.Type == shared.Approve {
+	switch result.FinalDecision.Type {
+	case shared.Approve:
 		if err := h.handleApprovalWithComments(result, mrInfo); err != nil {
 			logging.MRError(mrInfo.MRIID, "Failed to approve", err)
 			return c.Status(500).JSON(fiber.Map{
@@ -360,11 +390,15 @@ func (h *DataProductConfigMrReviewHandler) handleMergeRequestEvent(c *fiber.Ctx,
 			})
 		}
 		approved = true
-	} else {
+	case shared.CommentOnly:
+		if err := h.handleCommentOnlyWithComments(result, mrInfo); err != nil {
+			logging.MRError(mrInfo.MRIID, "Failed to add comment-only message", err)
+		}
+		logging.MRInfo(mrInfo.MRIID, "Comment only - no MR decision", zap.String("reason", result.FinalDecision.Reason))
+	default:
 		// Handle manual review with informational comments
 		if err := h.handleManualReviewWithComments(result, mrInfo); err != nil {
 			logging.MRError(mrInfo.MRIID, "Failed to add manual review comment", err)
-			// Continue - comment failure shouldn't block the webhook response
 		}
 		logging.MRInfo(mrInfo.MRIID, "Manual review required", zap.String("reason", result.FinalDecision.Reason))
 	}

--- a/internal/webhook/messages.go
+++ b/internal/webhook/messages.go
@@ -96,6 +96,9 @@ func (mb *MessageBuilder) buildDetailedSummary(result *shared.RuleEvaluation) st
 	summary.WriteString("**What was checked:**\n")
 	summary.WriteString(mb.buildRulesSummary(result.FileValidations))
 
+	// Ignored files section
+	summary.WriteString(mb.buildIgnoredFilesSummary(result))
+
 	summary.WriteString("\n</details>")
 
 	return summary.String()
@@ -519,6 +522,9 @@ func (mb *MessageBuilder) buildDetailedManualReviewSummary(result *shared.RuleEv
 		}
 	}
 
+	// Ignored files section
+	summary.WriteString(mb.buildIgnoredFilesSummary(result))
+
 	summary.WriteString("\n</details>")
 
 	return summary.String()
@@ -554,5 +560,40 @@ func (mb *MessageBuilder) buildDebugManualReviewSummary(result *shared.RuleEvalu
 	summary.WriteString(fmt.Sprintf("• Total files analyzed: %d\n", result.TotalFiles))
 	summary.WriteString(fmt.Sprintf("• Final decision: %s\n", result.FinalDecision.Type))
 
+	return summary.String()
+}
+
+// BuildCommentOnlyComment creates an informational comment when all files are ignored (no MR decision)
+func (mb *MessageBuilder) BuildCommentOnlyComment(result *shared.RuleEvaluation) string {
+	var comment strings.Builder
+
+	// Hidden identifier for comment tracking
+	comment.WriteString("<!-- naysayer-comment-id: comment-only -->\n")
+
+	// Header
+	comment.WriteString("ℹ️ **All files ignored** — no approval decision made\n\n")
+
+	// List ignored files
+	if len(result.IgnoredFiles) > 0 {
+		comment.WriteString("**Ignored files** (not evaluated):\n")
+		for _, f := range result.IgnoredFiles {
+			comment.WriteString(fmt.Sprintf("• `%s`\n", f))
+		}
+	}
+
+	return comment.String()
+}
+
+// buildIgnoredFilesSummary creates a summary section for ignored files (appended to approval/manual-review comments)
+func (mb *MessageBuilder) buildIgnoredFilesSummary(result *shared.RuleEvaluation) string {
+	if len(result.IgnoredFiles) == 0 {
+		return ""
+	}
+
+	var summary strings.Builder
+	summary.WriteString("\n**Ignored files** (not evaluated):\n")
+	for _, f := range result.IgnoredFiles {
+		summary.WriteString(fmt.Sprintf("• `%s`\n", f))
+	}
 	return summary.String()
 }

--- a/internal/webhook/messages_test.go
+++ b/internal/webhook/messages_test.go
@@ -287,3 +287,100 @@ func TestBuildManualReviewComment_IncludesNonEvaluatedManualReviewReason(t *test
 	assert.Contains(t, comment, "**What was checked:**")
 	assert.Contains(t, comment, fallbackReason)
 }
+
+func TestBuildCommentOnlyComment(t *testing.T) {
+	cfg := &config.Config{
+		Comments: config.CommentsConfig{
+			CommentVerbosity: "detailed",
+		},
+	}
+
+	builder := NewMessageBuilder(cfg)
+
+	result := &shared.RuleEvaluation{
+		FinalDecision: shared.Decision{
+			Type:   shared.CommentOnly,
+			Reason: "All changed files are in the ignore list - no decision made",
+		},
+		FileValidations: make(map[string]*shared.FileValidationSummary),
+		IgnoredFiles:    []string{"migration.sql", ".gitlab-ci.yml"},
+		ExecutionTime:   time.Millisecond * 10,
+	}
+
+	comment := builder.BuildCommentOnlyComment(result)
+
+	assert.Contains(t, comment, "<!-- naysayer-comment-id: comment-only -->")
+	assert.Contains(t, comment, "All files ignored")
+	assert.Contains(t, comment, "no approval decision made")
+	assert.Contains(t, comment, "`migration.sql`")
+	assert.Contains(t, comment, "`.gitlab-ci.yml`")
+	assert.Contains(t, comment, "**Ignored files**")
+}
+
+func TestBuildIgnoredFilesSummary_InApprovalComment(t *testing.T) {
+	cfg := &config.Config{
+		Comments: config.CommentsConfig{
+			CommentVerbosity: "detailed",
+		},
+	}
+
+	builder := NewMessageBuilder(cfg)
+
+	result := &shared.RuleEvaluation{
+		FinalDecision: shared.Decision{
+			Type:   shared.Approve,
+			Reason: "All files passed validation",
+		},
+		FileValidations: map[string]*shared.FileValidationSummary{
+			"dataproducts/source/product.yaml": {
+				FilePath:     "dataproducts/source/product.yaml",
+				TotalLines:   20,
+				CoveredLines: []shared.LineRange{{StartLine: 1, EndLine: 20}},
+				RuleResults: []shared.LineValidationResult{
+					{
+						RuleName:     "metadata_rule",
+						Decision:     shared.Approve,
+						Reason:       "Metadata validated",
+						LineRanges:   []shared.LineRange{{StartLine: 1, EndLine: 20}},
+						WasEvaluated: true,
+					},
+				},
+				FileDecision: shared.Approve,
+			},
+		},
+		TotalFiles:    1,
+		ApprovedFiles: 1,
+		IgnoredFiles:  []string{"migration.sql"},
+		ExecutionTime: time.Millisecond * 50,
+	}
+
+	mrInfo := &gitlab.MRInfo{
+		ProjectID: 123,
+		MRIID:     456,
+		Author:    "testuser",
+		Title:     "Test with ignored files",
+	}
+
+	comment := builder.BuildApprovalComment(result, mrInfo)
+
+	assert.Contains(t, comment, "✅ **Auto-approved**")
+	assert.Contains(t, comment, "**Ignored files** (not evaluated):")
+	assert.Contains(t, comment, "`migration.sql`")
+}
+
+func TestBuildIgnoredFilesSummary_Empty(t *testing.T) {
+	cfg := &config.Config{
+		Comments: config.CommentsConfig{
+			CommentVerbosity: "detailed",
+		},
+	}
+
+	builder := NewMessageBuilder(cfg)
+
+	result := &shared.RuleEvaluation{
+		IgnoredFiles: nil,
+	}
+
+	summary := builder.buildIgnoredFilesSummary(result)
+	assert.Empty(t, summary)
+}

--- a/rules.yaml
+++ b/rules.yaml
@@ -6,6 +6,10 @@ ignore_files:
   - name: "group_configs"
     path: "dataproducts/**/groups/"
     filename: "*.{yaml,yml}"
+  - name: "dataproduct_info"
+    path: "dataproducts/**/"
+    filename: "info.{yaml,yml}"
+
 
 files:
   # Product configuration files - Critical infrastructure validation

--- a/rules.yaml
+++ b/rules.yaml
@@ -2,6 +2,11 @@
 
 enabled: true
 
+ignore_files:
+  - name: "group_configs"
+    path: "dataproducts/**/groups/"
+    filename: "*.{yaml,yml}"
+
 files:
   # Product configuration files - Critical infrastructure validation
   - name: "product_configs"
@@ -117,20 +122,6 @@ files:
     filename: "developers.yaml"
     parser_type: yaml
     enabled: true
-    sections:
-      - name: full_file
-        yaml_path: .
-        rule_configs:
-          - name: metadata_rule
-            enabled: true
-        auto_approve: true
-
-  # Group configuration files - Low risk, can auto-approve
-  - name: "group_configs"
-    path: "dataproducts/**/groups/"
-    filename: "*.{yaml,yml}"
-    parser_type: yaml
-    enabled: false
     sections:
       - name: full_file
         yaml_path: .

--- a/rules.yaml
+++ b/rules.yaml
@@ -130,7 +130,7 @@ files:
     path: "dataproducts/**/groups/"
     filename: "*.{yaml,yml}"
     parser_type: yaml
-    enabled: true
+    enabled: false
     sections:
       - name: full_file
         yaml_path: .


### PR DESCRIPTION
## Description

Brief description of what this PR does.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧪 Test addition or improvement
- [ ] 🔨 Build/CI changes

## Related Issues

Fixes #(issue number)

## Testing

- [ ] Unit tests pass (`make test`)
- [ ] Linting passes (`make lint`)
- [ ] Manual testing completed
- [ ] Coverage maintained or improved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * Group configuration files and product metadata files matching supported ignore patterns are now excluded from validation.
  * Removed automatic approval behavior for group configuration checks.

* **Validation**
  * Changes containing only ignored files now receive an informational comment without approval or rejection.
  * Valid files continue through normal validation and approval workflows.
  * Approval and review comments now identify ignored files when applicable.
  * Comment-only decision labels now support common formatting variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->